### PR TITLE
[Fix] Version up nodejs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN yum install -y epel-release httpd
 # https://github.com/eclipse/mosquitto/issues/1740
 # so download from fedora archive
 RUN yum install -y https://archive.fedoraproject.org/pub/archive/epel/7.2020-04-20/x86_64/Packages/m/mosquitto-1.6.8-1.el7.x86_64.rpm certbot
-ENV NODEJS_VERSION=v16.14.0
+ENV NODEJS_VERSION=v16.19.1
 RUN wget -qO - https://nodejs.org/dist/${NODEJS_VERSION}/node-${NODEJS_VERSION}-linux-x64.tar.xz | tar xf - -C /usr/local -J \
   && ln -s /usr/local/node-${NODEJS_VERSION}-linux-x64 /usr/local/nodejs && ln -s /usr/local/nodejs/bin/node /usr/bin/node && ln -s /usr/local/nodejs/bin/npm /usr/bin/npm
 RUN wget -qO - https://github.com/procube-open/shibboleth-fcgi-rpm/releases/download/3.0.1-3.2/shibboleth-fcgi-rpm.tar.gz | tar -xzf -


### PR DESCRIPTION
CVE-2022-43548, CVE-2022-35256 などの脆弱性に対応するため、 nodejs をバージョンアップする